### PR TITLE
fixed bug for bad logs due to assigning array without copy

### DIFF
--- a/initStates.ts
+++ b/initStates.ts
@@ -61,4 +61,4 @@ export const initStateTwo: GameState = {
 }
 
 
-export const botsTwo = new BotPool(["./a.out", "./a.out"]);
+export const botsTwo = new BotPool(["./bots/bot_a", "./bots/bot_b"]);

--- a/quoridor.ts
+++ b/quoridor.ts
@@ -476,9 +476,9 @@ function startingPosToString(state: GameState, player: PlayerID): string {
 function tickToVisualizer(botPool: BotPool, state: GameState, userSteps: UserStep[]): void {
   tickLog.push({
     currentPlayer: state.tick.currentPlayer,
-    pawnPos: state.tick.pawnPos,
-    walls: state.tick.walls,
-    ownedWalls: state.tick.ownedWalls,
+    pawnPos: [ ...state.tick.pawnPos],
+    walls: [ ...state.tick.walls],
+    ownedWalls: [ ...state.tick.ownedWalls],
     action: userSteps[0], // There is only one player now
     bots: botPool.bots.map((bot, index) => ({
       id: bot.id,


### PR DESCRIPTION
There was a bug where in the logs the array properties were the same for each tick.

This was due to how javascript only copies the reference to an array and not the array itself, it can be copied with the spread operator.